### PR TITLE
Permet à l'utilisateur de comparer deux versions de son tutoriel

### DIFF
--- a/assets/js/compare-commits.js
+++ b/assets/js/compare-commits.js
@@ -1,0 +1,43 @@
+/*
+ * Allow the user to compare two commits
+ */
+
+(function(document, $, undefined){
+    "use strict";
+
+    function toogleRadioInput($radioInput){
+        var $row = $radioInput.parent().parent();
+
+        if($radioInput.attr("name") === "compare-from") {
+            $row.prevAll().find("[name='compare-to']").prop("disabled", false);
+            $row.nextAll().find("[name='compare-to']").prop("disabled", true);
+            $row.find("[name='compare-to']").prop("disabled", true);
+        }
+        else {
+            $row.prevAll().find("[name='compare-from']").prop("disabled", true);
+            $row.nextAll().find("[name='compare-from']").prop("disabled", false);
+            $row.find("[name='compare-from']").prop("disabled", true);
+        }
+    }
+
+    $(".commits-list input[name^='compare']").on("change", function(){
+        toogleRadioInput($(this));
+    });
+
+    $(document).ready(function(){
+        $(".commits-list input[name^='compare']:checked").each(function(){
+            toogleRadioInput($(this));
+        });
+    });
+
+    $(".commits-compare-form").on("submit", function(){
+        var $form = $(this),
+            $fromInput = $form.find("input[name='from']"),
+            $toInput = $form.find("input[name='to']"),
+            compareFrom = $(".commits-list input[name='compare-from']:checked").val(),
+            compareTo = $(".commits-list input[name='compare-to']:checked").val();
+
+        $fromInput.val(compareFrom);
+        $toInput.val(compareTo);
+    });
+})(document, jQuery);

--- a/assets/scss/main.scss
+++ b/assets/scss/main.scss
@@ -80,6 +80,7 @@
 @import "pages/gallery";
 @import "pages/api";
 @import "pages/tutorial-help";
+@import "pages/tutorial-history";
 
 /*-------------------------
 10. High pixel ratio (retina)

--- a/assets/scss/pages/_tutorial-history.scss
+++ b/assets/scss/pages/_tutorial-history.scss
@@ -1,0 +1,3 @@
+.commits-compare-form button {
+    float: none !important;
+}

--- a/templates/tutorial/tutorial/history.html
+++ b/templates/tutorial/tutorial/history.html
@@ -51,10 +51,18 @@
 
 
 {% block content %}
-    <table class="fullwidth">
+    <form method="get" action="{% url "zds.tutorial.views.diff" tutorial.pk tutorial.slug %}" class="commits-compare-form">
+        <input type="hidden" name="from" value="">
+        <input type="hidden" name="to" value="">
+
+        <button class="btn btn-grey" type="submit">{% trans "Comparer les versions sélectionnées" %}</button>
+    </form>
+
+    <table class="fullwidth commits-list">
         <thead>
             <tr>
                 <th width="10%">{% trans "État" %}</th>
+                <th colspan="2">{% trans "Comparer" %}</th>
                 <th width="18%">{% trans "Date" %}</th>
                 <th>{% trans "Version" %}</th>
                 <th width="10%">{% trans "Diff" %}.</th>
@@ -89,6 +97,24 @@
                                     </li>
                                 {% endif %}
                             </ul>
+                        {% endif %}
+                    </td>
+                    <td>
+                        {% if not forloop.first %}
+                            <input type="radio" name="compare-from" value="{{ commit.hexsha }}"
+                                {% if forloop.counter == 2 %}
+                                    checked="checked"
+                                {% endif %}
+                            >
+                        {% endif %}
+                    </td>
+                    <td>
+                        {% if not forloop.last %}
+                            <input type="radio" name="compare-to" value="{{ commit.hexsha }}"
+                                {% if forloop.first %}
+                                    checked="checked"
+                                {% endif %}
+                            >
                         {% endif %}
                     </td>
                     <td>


### PR DESCRIPTION
Voilà une PR pour la fonctionnalité que tu voulais :

> Je précise que la possibilité de comparer deux versions quelconques ("à la wikipédia") est désormais très simple à faire, il suffit de faire les changements ci-dessous par exemple.
> 
> Exemple wikipédia: https://fr.wikipedia.org/w/index.php?title=Zeste&action=history
> 
> Je ne les ai pas fait car je me suis heurté avec deux problèmes du **front**:
> - la présence de `<form>` pour la mise en béta dans le `<table>` (impossible d'imbriquer des form…)

Résolu avec un `<form>` en dehors du `<table>` et un bout de JS !

> - le bouton `submit` impossible à ressoumettre si on utilise le bouton Précédent du navigateur en revenant sur la page précédente oO

Oui ça c'est parce qu'au clic d'un bouton on met tous les autres boutons en *disabled* donc du coup quand on fait précédente, le navigo retient que tous les boutons on été mis en *disabled*.

> - il faudrait ajouter un script JS qui lors du click sur un input radio *to* déplace le radio *from* si celui-ci est situé avant, voire en masque certains… (à la manière de Wikipédia).

C'est fait ! La différence est qu'au lieu d'afficher/cacher les boutons, on les active/désactive avec l'attribut `disabled`.